### PR TITLE
Explicit import of NavigationHelper in NavigationHelperUIKit target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,8 @@ let package = Package(
                 "FunctionalKit",
                 "Abstract",
                 "Log",
-                "RxSwift"
+                "RxSwift",
+                "NavigationHelper"
             ]),
         .testTarget(
             name: "NavigationHelperTests",


### PR DESCRIPTION
This change is necessary to create a correct archive from a project that imports NavigationHelper and uses NavigationHelperUIKit